### PR TITLE
 fix: [MV-011 & DV-009] sorting functionality on mobile & desktop; fixed infinite data fetching caused by pagination on mobile devices

### DIFF
--- a/src/components/Catalog/Catalog.tsx
+++ b/src/components/Catalog/Catalog.tsx
@@ -47,10 +47,9 @@ export const Catalog: FC<ICatalogProps> = ({ data, totalPages }) => {
   useEffect(() => {
     if (!isMobile767 || !observerRef.current) return;
 
-    console.log('I AM USE EFFECT THAT SETS APPENDING TO TRUE');
+    dispatch(setIsAppending(true));
     const observer = new IntersectionObserver(
       ([entry]) => {
-        dispatch(setIsAppending(true));
         if (entry.isIntersecting && hasMore && !isFetchingMore) {
           console.log('I AM MAKING NEW REQUESt');
 

--- a/src/components/Catalog/Catalog.tsx
+++ b/src/components/Catalog/Catalog.tsx
@@ -44,7 +44,6 @@ export const Catalog: FC<ICatalogProps> = ({ data, totalPages }) => {
   console.log('hasMore', hasMore);
 
   console.log('isFetchingMore: ', isFetchingMore);
-  // встановлення isAppending на true!
   useEffect(() => {
     if (!isMobile767 || !observerRef.current) return;
 
@@ -54,7 +53,6 @@ export const Catalog: FC<ICatalogProps> = ({ data, totalPages }) => {
           console.log('I AM MAKING NEW REQUESt');
 
           dispatch(setIsAppending(true));
-          // тригерить безкінечні ререндер (setPageNumber)
           dispatch(setPageNumber(pagination.currentPage + 1));
         }
       },
@@ -70,8 +68,6 @@ export const Catalog: FC<ICatalogProps> = ({ data, totalPages }) => {
     return () => {
       observer.unobserve(target);
     };
-
-    // ЗАЛЕЖНІСТЬ isFetchingMore вирішує безкінечний ререндер
   }, [hasMore, isMobile767, pagination.currentPage, isFetchingMore, dispatch]);
 
   return (

--- a/src/components/Catalog/Catalog.tsx
+++ b/src/components/Catalog/Catalog.tsx
@@ -37,13 +37,24 @@ export const Catalog: FC<ICatalogProps> = ({ data, totalPages }) => {
     query: '(max-width: 767px)',
   });
 
+  console.log('CURRENT PAGE: ', pagination.currentPage);
+  console.log('TOTAL PAGES FROM REDUX: ', pagination.totalPages);
+  console.log('TOTAL PAGES FROM PROPS: ', totalPages);
+
+
+  console.log('isFetchingMore: ', isFetchingMore);
+  // встановлення isAppending на true!
   useEffect(() => {
     if (!isMobile767 || !observerRef.current) return;
 
-    dispatch(setIsAppending(true));
+    console.log('I AM USE EFFECT THAT SETS APPENDING TO TRUE');
     const observer = new IntersectionObserver(
       ([entry]) => {
+        dispatch(setIsAppending(true));
         if (entry.isIntersecting && hasMore && !isFetchingMore) {
+          console.log('I AM MAKING NEW REQUESt');
+
+          // тригерить безкінечні ререндер (setPageNumber)
           dispatch(setPageNumber(pagination.currentPage + 1));
         }
       },

--- a/src/components/Catalog/Catalog.tsx
+++ b/src/components/Catalog/Catalog.tsx
@@ -29,7 +29,6 @@ export const Catalog: FC<ICatalogProps> = ({ data, totalPages }) => {
   useEffect(() => {
     if (pagination.totalPages) {
       setHasMore(pagination.currentPage < pagination.totalPages - 1);
-      // 0 < (2-1)
     }
   }, [pagination]);
 

--- a/src/components/Catalog/Catalog.tsx
+++ b/src/components/Catalog/Catalog.tsx
@@ -50,8 +50,6 @@ export const Catalog: FC<ICatalogProps> = ({ data, totalPages }) => {
     const observer = new IntersectionObserver(
       ([entry]) => {
         if (entry.isIntersecting && hasMore && !isFetchingMore) {
-          console.log('I AM MAKING NEW REQUESt');
-
           dispatch(setIsAppending(true));
           dispatch(setPageNumber(pagination.currentPage + 1));
         }

--- a/src/components/Catalog/Catalog.tsx
+++ b/src/components/Catalog/Catalog.tsx
@@ -37,13 +37,6 @@ export const Catalog: FC<ICatalogProps> = ({ data, totalPages }) => {
     query: '(max-width: 767px)',
   });
 
-  console.log('CURRENT PAGE: ', pagination.currentPage);
-  console.log('TOTAL PAGES FROM REDUX: ', pagination.totalPages);
-  console.log('TOTAL PAGES FROM PROPS: ', totalPages);
-  console.log('IS FETCHING MORE', isFetchingMore);
-  console.log('hasMore', hasMore);
-
-  console.log('isFetchingMore: ', isFetchingMore);
   useEffect(() => {
     if (!isMobile767 || !observerRef.current) return;
 

--- a/src/components/Catalog/Catalog.tsx
+++ b/src/components/Catalog/Catalog.tsx
@@ -29,6 +29,7 @@ export const Catalog: FC<ICatalogProps> = ({ data, totalPages }) => {
   useEffect(() => {
     if (pagination.totalPages) {
       setHasMore(pagination.currentPage < pagination.totalPages - 1);
+      // 0 < (2-1)
     }
   }, [pagination]);
 
@@ -40,19 +41,20 @@ export const Catalog: FC<ICatalogProps> = ({ data, totalPages }) => {
   console.log('CURRENT PAGE: ', pagination.currentPage);
   console.log('TOTAL PAGES FROM REDUX: ', pagination.totalPages);
   console.log('TOTAL PAGES FROM PROPS: ', totalPages);
-
+  console.log('IS FETCHING MORE', isFetchingMore);
+  console.log('hasMore', hasMore);
 
   console.log('isFetchingMore: ', isFetchingMore);
   // встановлення isAppending на true!
   useEffect(() => {
     if (!isMobile767 || !observerRef.current) return;
 
-    dispatch(setIsAppending(true));
     const observer = new IntersectionObserver(
       ([entry]) => {
         if (entry.isIntersecting && hasMore && !isFetchingMore) {
           console.log('I AM MAKING NEW REQUESt');
 
+          dispatch(setIsAppending(true));
           // тригерить безкінечні ререндер (setPageNumber)
           dispatch(setPageNumber(pagination.currentPage + 1));
         }
@@ -69,6 +71,8 @@ export const Catalog: FC<ICatalogProps> = ({ data, totalPages }) => {
     return () => {
       observer.unobserve(target);
     };
+
+    // ЗАЛЕЖНІСТЬ isFetchingMore вирішує безкінечний ререндер
   }, [hasMore, isMobile767, pagination.currentPage, isFetchingMore, dispatch]);
 
   return (

--- a/src/components/Filters/Filters.tsx
+++ b/src/components/Filters/Filters.tsx
@@ -12,7 +12,6 @@ import FiltersSvg from '@/assets/icons/filters.svg';
 import FilterRateSvg from '@/assets/icons/filter-rate.svg';
 
 import styles from './filters.module.scss';
-import { useTypedSelector } from '@/hooks/useTypedSelector';
 import { setIsAppending } from '@/store/products/products_slice';
 
 export const Filters = () => {

--- a/src/components/Filters/Filters.tsx
+++ b/src/components/Filters/Filters.tsx
@@ -12,7 +12,7 @@ import FiltersSvg from '@/assets/icons/filters.svg';
 import FilterRateSvg from '@/assets/icons/filter-rate.svg';
 
 import styles from './filters.module.scss';
-import { setIsAppending } from '@/store/products/products_slice';
+import { setIsAppending, setPageNumber } from '@/store/products/products_slice';
 
 export const Filters = () => {
   const [drawerVisible, setDrawerVisible] = useState(false);
@@ -26,19 +26,13 @@ export const Filters = () => {
   const toggleDrawer = () => setDrawerVisible((prev) => !prev);
   const toggleSort = () => setSortVisible((prev) => !prev);
 
-  // TEST
-  const { isAppending } = useTypedSelector(
-    (state: RootState) => state.products,
-  );
-
   const handleFilter = () => {
     setDrawerVisible(false);
   };
-  console.log('isAppending: ', isAppending);
 
   const handleSort = (value: string) => {
     dispatch(setSelectedSort(value));
-    // дані не будуть приліпюватись до вже наявних даних - сортування ок
+    dispatch(setPageNumber(0));
     dispatch(setIsAppending(false));
   };
 

--- a/src/components/Filters/Filters.tsx
+++ b/src/components/Filters/Filters.tsx
@@ -12,6 +12,8 @@ import FiltersSvg from '@/assets/icons/filters.svg';
 import FilterRateSvg from '@/assets/icons/filter-rate.svg';
 
 import styles from './filters.module.scss';
+import { useTypedSelector } from '@/hooks/useTypedSelector';
+import { setIsAppending } from '@/store/products/products_slice';
 
 export const Filters = () => {
   const [drawerVisible, setDrawerVisible] = useState(false);
@@ -25,12 +27,20 @@ export const Filters = () => {
   const toggleDrawer = () => setDrawerVisible((prev) => !prev);
   const toggleSort = () => setSortVisible((prev) => !prev);
 
+  // TEST
+  const { isAppending } = useTypedSelector(
+    (state: RootState) => state.products,
+  );
+
   const handleFilter = () => {
     setDrawerVisible(false);
   };
+  console.log('isAppending: ', isAppending);
 
   const handleSort = (value: string) => {
     dispatch(setSelectedSort(value));
+    // дані не будуть приліпюватись до вже наявних даних - сортування ок
+    dispatch(setIsAppending(false));
   };
 
   return (

--- a/src/pages/Category/Category.tsx
+++ b/src/pages/Category/Category.tsx
@@ -7,6 +7,7 @@ import { useTypedSelector } from '@/hooks/useTypedSelector';
 import { useActions } from '@/hooks/useActions';
 import { useDispatch } from 'react-redux';
 import { resetFilters } from '@/store/filters/filters_slice';
+import { setPageNumber } from '@/store/products/products_slice';
 
 function Category() {
   const { productsData } = useTypedSelector(
@@ -26,6 +27,7 @@ function Category() {
 
   useEffect(() => {
     if (isValidCategory) {
+      dispatch(setPageNumber(0));
       dispatch(resetFilters());
       setSelectedCategory(categoryId);
     }


### PR DESCRIPTION
KEY CHANGES:

**Corrected Sorting Logic**: When a new sort option is selected (e.g., by price, popularity), the product list now correctly resets to the first page (page 0). This prevents incorrect data display that could occur in some cases


**Controlled Appending for Sort Changes**: The setIsAppending(false) flag is now explicitly set when applying a new sort or . This is crucial for preventing unexpected "append" behavior (where new items might load below existing ones from a previous state) and ensures that the product list starts fresh.