### PR TITLE
Fix: page number is set to 0 when the user changes sorting option

### DIFF
--- a/src/components/Sort/SortingDesk.tsx
+++ b/src/components/Sort/SortingDesk.tsx
@@ -13,6 +13,7 @@ import SortSvg from '@/assets/icons/sorting.svg';
 import ArrowUpSvg from '@/assets/icons/arrow-up.svg';
 
 import styles from './sort.module.scss';
+import { setPageNumber } from '@/store/products/products_slice';
 
 export const SortingDesk = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -30,6 +31,7 @@ export const SortingDesk = () => {
 
   const handleSortSelection = (value: string) => {
     dispatch(setSelectedSort(value));
+    dispatch(setPageNumber(0));
     setIsModalOpen(false);
   };
 


### PR DESCRIPTION
One line changes: setting page number to 0 when changing sorting option improving UX