### PR TITLE
fix(breadcrumbs): fix incorrect category display when navigating from…

### DIFF
--- a/src/components/BasketItem/BasketItemMobile.tsx
+++ b/src/components/BasketItem/BasketItemMobile.tsx
@@ -1,6 +1,5 @@
 import { Link } from 'react-router-dom';
 import styles from './basketitem.module.scss';
-
 import { useTypedSelector } from '@/hooks/useTypedSelector';
 import {
   BasketMinusBtn,
@@ -20,27 +19,38 @@ function BasketItemMobile({
   handleSaveFavoriteProduct,
   isLikedProduct,
 }: IBasketChildren) {
-  const { id, name, code, images, quantity, totalPrice, href, categoryId } =
-    product;
+  const {
+    id,
+    name,
+    code,
+    images,
+    quantity,
+    totalPrice,
+    href,
+    categoryId,
+    categoryResponseDto,
+  } = product;
+
   const { locale, currency } = useTypedSelector((state) => state.shopping_card);
-  const formatCategoryName = getFormattedCategoryName(categoryId);
+  const actualCategoryId = categoryResponseDto?.id || categoryId;
+  const formatCategoryName = getFormattedCategoryName(actualCategoryId);
+  const targetUrl = `/${formatCategoryName}/${id}/${href}`;
 
   return (
     <>
       <div className={styles.mobilePopup}>
         <div className={styles.top}>
-          <Link
-            to={`/${formatCategoryName}/${id}/${href}`}
-            className={styles.productImg}
-          >
+          <Link to={targetUrl} className={styles.productImg}>
             <img src={images?.[0].link} alt={name} />
           </Link>
+
           <div>
-            <Link to={`/${formatCategoryName}/${id}/${href}`}>
+            <Link to={targetUrl}>
               <h2 className={styles.mobilePopupTitle}>{name}</h2>
             </Link>
             <p className={styles.mobilePopupCode}>code:{code}</p>
           </div>
+
           <div>
             <button
               className={styles.mobilePopupClose}
@@ -53,7 +63,9 @@ function BasketItemMobile({
             </h3>
           </div>
         </div>
+
         <div className={styles.devider}></div>
+
         <div className={styles.bottom}>
           <div className={styles.mobilePopupQuantity}>
             <button onClick={handleDecreaseItemQuantity}>
@@ -64,6 +76,7 @@ function BasketItemMobile({
               <img src={BasketPlusBtn} alt="quantity-Inrease-Button" />
             </button>
           </div>
+
           <>
             <HeartIcon
               onClick={handleSaveFavoriteProduct}

--- a/src/components/BasketItem/BasketItemPC.tsx
+++ b/src/components/BasketItem/BasketItemPC.tsx
@@ -1,30 +1,51 @@
-import { Link } from "react-router-dom";
+import { Link } from 'react-router-dom';
 import styles from './basketitem.module.scss';
-import { useTypedSelector } from "@/hooks/useTypedSelector";
+import { useTypedSelector } from '@/hooks/useTypedSelector';
 import { deleteFromBasketMob } from '@/assets/constants.ts';
-import { DeleteFromBasket } from "@/assets/icons/DeleteFromBasket";
-import { HeartIcon } from "@/assets/icons/HeartIcon";
+import { DeleteFromBasket } from '@/assets/icons/DeleteFromBasket';
+import { HeartIcon } from '@/assets/icons/HeartIcon';
 import { convertPriceToReadable } from '@/utils/helpers/product';
-import { IBasketChildren } from "./type/interfaces";
-import getFormattedCategoryName from "@/hooks/getFormattedCategoryName";
+import { IBasketChildren } from './type/interfaces';
+import getFormattedCategoryName from '@/hooks/getFormattedCategoryName';
 
-function BasketItemPC({product, handleDeleteFromStore, handleDecreaseItemQuantity, handleIncrementItemQuantity, handleSaveFavoriteProduct, isLikedProduct}: IBasketChildren) {
-  const { id, name, code, images, totalPrice, href, categoryId } = product;
+function BasketItemPC({
+  product,
+  handleDeleteFromStore,
+  handleDecreaseItemQuantity,
+  handleIncrementItemQuantity,
+  handleSaveFavoriteProduct,
+  isLikedProduct,
+}: IBasketChildren) {
+  const {
+    id,
+    name,
+    code,
+    images,
+    totalPrice,
+    href,
+    categoryId,
+    categoryResponseDto,
+  } = product;
+
   const { locale, currency } = useTypedSelector((state) => state.shopping_card);
-  const formatCategoryName = getFormattedCategoryName(categoryId)
-  
+  const actualCategoryId = categoryResponseDto?.id || categoryId;
+  const formatCategoryName = getFormattedCategoryName(actualCategoryId);
+  const targetUrl = `/${formatCategoryName}/${id}/${href}`;
+
   return (
     <>
       <div className={styles.basketItem}>
-        <Link to={`/${formatCategoryName}/${id}/${href}`}  className={styles.productImg}>
+        <Link to={targetUrl} className={styles.productImg}>
           <img src={images?.[0].link} alt={name} />
         </Link>
+
         <div className={styles.productInfo}>
-          <Link to={`/${formatCategoryName}/${id}/${href}`}>
+          <Link to={targetUrl}>
             <h2 className={styles.productTitle}>{name}</h2>
           </Link>
 
           <p className={styles.productCode}>code:{code}</p>
+
           <span className={styles.productBottom}>
             <button onClick={handleDeleteFromStore}>
               <DeleteFromBasket />
@@ -43,14 +64,14 @@ function BasketItemPC({product, handleDeleteFromStore, handleDecreaseItemQuantit
             />
           </span>
         </div>
+
         <div className={styles.productTotals}>
           <div className={styles.productQuantity}>
             <div className={styles.productQuantityButton}>
               <button
                 className={styles.productQuantityButton_minus}
                 onClick={handleDecreaseItemQuantity}
-              >
-              </button>
+              ></button>
             </div>
 
             <p>{product.quantity}</p>
@@ -62,11 +83,12 @@ function BasketItemPC({product, handleDeleteFromStore, handleDecreaseItemQuantit
               ></button>
             </div>
           </div>
+
           <p className={styles.productPrice}>
             {convertPriceToReadable(totalPrice, currency, locale)}
           </p>
         </div>
-      </div> 
+      </div>
     </>
   );
 }

--- a/src/interfaces/interfaces.ts
+++ b/src/interfaces/interfaces.ts
@@ -47,7 +47,7 @@ export interface IProductOtherColors {
   categoryId: number;
 }
 export interface IProductOtherModels {
-  productId: number,
+  productId: number;
   attributeValue: string;
   available: boolean;
   href: string;
@@ -73,11 +73,17 @@ export interface IProductCard {
   category?: string;
   available?: boolean;
   categoryId?: number;
+  categoryResponseDto?: {
+    id: number;
+    name: string;
+    urlSlug?: string;
+    displayName?: string;
+  };
   alternativeProducts?: {
     color?: IProductOtherColors[];
-    model?: IProductOtherModels[],
-    romMemory?: iProductMemoryCards[],
-  }
+    model?: IProductOtherModels[];
+    romMemory?: iProductMemoryCards[];
+  };
 }
 
 export interface IShoppingCard extends IProductCard {


### PR DESCRIPTION
Fix: Breadcrumbs Show "Unknown" When Navigating From Cart

Problem
Breadcrumbs displayed "Unknown" instead of correct category names when users clicked on products from the shopping cart.

Example:
- Before: Home > Unknown > Apple iPhone 13
- After: Home > Smartphone > Apple iPhone 13

Root Cause  
Cart items have different data structure (`categoryResponseDto.id`) compared to catalog items (`categoryId`), causing URL generation to fallback to `/unknown/...`

 Solution
- Added category extraction logic for cart items
- Fixed breadcrumb path generation from shopping cart
- Updated TypeScript interfaces for proper type support

Impact
- Breadcrumbs now show correct category hierarchy
- Improved user navigation experience from cart
- Consistent URL structure across the application